### PR TITLE
Update README Development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Install from F-Droid, Google Play, or download APK from GitHub.
 ## Development
 
 ```
+rm yarn.lock
 bun link
 bun install
 bun dev


### PR DESCRIPTION
On Windows 11, doing `bun install` in repo root will by default give:

```
PS J:\Repos\Nora\desktop> bun install
bun install v1.3.10 (30e609e0)

To install a linked package:
   bun link my-pkg-name-from-package-json

Tip: the package name is from package.json, which can differ from the folder name.

error: nora@link:nora failed to resolve
```

Doing `bun link` in repo root resolves. Not sure if this is common knowledge with bun or what - new to me!

Also adds `rm yarn.lock` to resolve https://github.com/nonbili/Nora/issues/199#issuecomment-4001709369